### PR TITLE
Change username and pw for postgresql db

### DIFF
--- a/apps/slatefinder/config/config.exs
+++ b/apps/slatefinder/config/config.exs
@@ -31,7 +31,7 @@ use Mix.Config
 config :slatefinder, Slatefinder.Repo,
   adapter: Ecto.Adapters.Postgres,
   database: "slatefinder",
-  username: "[USERNAME]",
-  password: ""
+  username: "postgres",
+  password: "postgres"
 
 config :slatefinder, ecto_repos: [Slatefinder.Repo]


### PR DESCRIPTION
mix init failed because it couldn't connect to the db. I had no user with the user name "[USERNAME]" and no pw. I changed it to postgres for both, which I believe is the default that gets created with postgresql is installed. We'll probably want to change this later and add it to environment variables or something.